### PR TITLE
Changing url of Zilliqa JSON RPC

### DIFF
--- a/Example/Source/Application/Scenes/Send/SendViewModel.swift
+++ b/Example/Source/Application/Scenes/Send/SendViewModel.swift
@@ -56,7 +56,7 @@ extension SendViewModel: ViewModelType {
 
         let _keyPair = self.wallet.keyPair
         let wallet: Driver<Wallet> = balanceAndNonce.map { balance in
-            let amount = try! Amount(double: Double(balance.balance)!)
+            let amount = try! Amount(double: balance.balance)
             return Wallet(keyPair: _keyPair, balance: amount, nonce: Nonce(balance.nonce))
         }
 

--- a/Source/Services/APIModels/Balance/BalanceResponse.swift
+++ b/Source/Services/APIModels/Balance/BalanceResponse.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 public struct BalanceResponse: Decodable {
-    public let balance: String
+    public let balance: Double
     public let nonce: Int
 }

--- a/Source/Services/APIModels/ZilliqaRequest.swift
+++ b/Source/Services/APIModels/ZilliqaRequest.swift
@@ -17,7 +17,7 @@ public struct ZilliqaRequest<Batch: JSONRPCKit.Batch>: APIKit.Request {
 
 public extension ZilliqaRequest {
     var baseURL: URL {
-        return URL(string: "https://scillaprod-api.aws.zilliqa.com")!
+        return URL(string: "https://testnet-scilla-prod-api.aws.zilliqa.com")!
     }
 
     var method: HTTPMethod {


### PR DESCRIPTION
from `scillaprod-api.aws.zilliqa.com` to `testnet-scilla-prod-api.aws.zilliqa.com` (just a name change by the Zilliqa team. It has always been testnet.) And updated the BalanceResponse to be a `Double` instead of a `String`