### PR TITLE
Poll tx status

### DIFF
--- a/Example/Source/Application/Scenes/Send/SendView.swift
+++ b/Example/Source/Application/Scenes/Send/SendView.swift
@@ -17,9 +17,9 @@ final class SendView: ScrollingStackView {
     private lazy var walletBalanceView = WalletBalanceView()
 
     private lazy var recipientAddressField = UITextField.Style("To address", text: "74C544A11795905C2C9808F9E78D8156159D32E4").make()
-    private lazy var amountToSendField = UITextField.Style("Amount", text: "11").make()
+    private lazy var amountToSendField = UITextField.Style("Amount", text: "1234").make()
     private lazy var gasLimitField = UITextField.Style("Gas limit", text: "1").make()
-    private lazy var gasPriceField = UITextField.Style("Gas price", text: "100").make()
+    private lazy var gasPriceField = UITextField.Style("Gas price", text: "150").make()
     private lazy var encryptionPassphrase = UITextField.Style("Wallet Encryption Passphrase", text: "Apa").make()
     private lazy var sendButton: UIButton = "Send"
     private lazy var transactionIdentifierLabel: UILabel = "No tx"
@@ -60,7 +60,7 @@ extension SendView: ViewModelled {
             viewModel.address           --> walletBalanceView.rx.address,
             viewModel.balance           --> walletBalanceView.rx.balance,
             viewModel.nonce           --> walletBalanceView.rx.nonce,
-            viewModel.transactionId     --> transactionIdentifierLabel
+            viewModel.receipt    --> transactionIdentifierLabel
         ]
     }
 }

--- a/Source/Extensions/DispatchQueue+Sugar.swift
+++ b/Source/Extensions/DispatchQueue+Sugar.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-func background(work: @escaping () -> ()) {
-    DispatchQueue.global(qos: .userInitiated).async {
+func background(delay: DispatchTimeInterval = .seconds(0), work: @escaping () -> ()) {
+    DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + delay) {
         work()
     }
 }

--- a/Source/Services/APIModels/Transaction/StatusOfTransactionRequest.swift
+++ b/Source/Services/APIModels/Transaction/StatusOfTransactionRequest.swift
@@ -9,6 +9,16 @@
 import Foundation
 import JSONRPCKit
 
+// The receipt for a transaction that the network has reached consensus for.
+public struct TransactionReceipt {
+    public let transactionId: String
+    public let totalGasCost: Amount
+    public init(id: String, totalGasCost: Amount) {
+        self.transactionId = id
+        self.totalGasCost = totalGasCost
+    }
+}
+
 public struct StatusOfTransactionResponse: Decodable {
     public struct Receipt {
         public let totalGasCost: Amount

--- a/Source/Services/APIModels/Transaction/StatusOfTransactionRequest.swift
+++ b/Source/Services/APIModels/Transaction/StatusOfTransactionRequest.swift
@@ -19,6 +19,13 @@ public struct TransactionReceipt {
     }
 }
 
+public extension TransactionReceipt {
+    init?(for id: String, pollResponse: StatusOfTransactionResponse) {
+        guard pollResponse.receipt.isSent else { return nil }
+        self.init(id: id, totalGasCost: pollResponse.receipt.totalGasCost)
+    }
+}
+
 public struct StatusOfTransactionResponse: Decodable {
     public struct Receipt {
         public let totalGasCost: Amount

--- a/Source/Services/APIModels/Transaction/StatusOfTransactionRequest.swift
+++ b/Source/Services/APIModels/Transaction/StatusOfTransactionRequest.swift
@@ -1,0 +1,54 @@
+//
+//  StatusOfTransactionRequest.swift
+//  Zesame
+//
+//  Created by Alexander Cyon on 2018-12-11.
+//  Copyright © 2018 Open Zesame. All rights reserved.
+//
+
+import Foundation
+import JSONRPCKit
+
+public struct StatusOfTransactionResponse: Decodable {
+    public struct Receipt {
+        public let totalGasCost: Amount
+        public let isSent: Bool
+    }
+
+    public let receipt: Receipt
+}
+
+extension StatusOfTransactionResponse.Receipt: Decodable {}
+public extension StatusOfTransactionResponse.Receipt {
+
+    enum CodingKeys: String, CodingKey {
+        case totalGasCost = "cumulative_gas"
+        case isSent = "success"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let costAsString = try container.decode(String.self, forKey: .totalGasCost)
+        self.totalGasCost = try Amount(string: costAsString)
+        self.isSent = try container.decode(Bool.self, forKey: .isSent)
+    }
+}
+
+public struct StatusOfTransactionRequest: JSONRPCKit.Request {
+    public typealias Response = StatusOfTransactionResponse
+
+    public let transactionId: String
+    public init(transactionId: String) {
+        self.transactionId = transactionId
+    }
+}
+
+public extension StatusOfTransactionRequest {
+    var method: String {
+        return "GetTransaction"
+    }
+
+    var parameters: Encodable? {
+        return [transactionId]
+    }
+}

--- a/Source/Services/APIModels/ZilliqaRequest.swift
+++ b/Source/Services/APIModels/ZilliqaRequest.swift
@@ -17,7 +17,7 @@ public struct ZilliqaRequest<Batch: JSONRPCKit.Batch>: APIKit.Request {
 
 public extension ZilliqaRequest {
     var baseURL: URL {
-        return URL(string: "https://api-scilla.zilliqa.com")!
+        return URL(string: "https://api.zilliqa.com")!
     }
 
     var method: HTTPMethod {

--- a/Source/Services/Error.swift
+++ b/Source/Services/Error.swift
@@ -19,6 +19,8 @@ public enum Error: Swift.Error {
         /// Error while creating `URLRequest` from `Request`.
         case requestError(Swift.Error)
 
+        case timeout
+
         /// Error while creating `Request.Response` from `(Data, URLResponse)`.
         case responseError(Swift.Error)
 

--- a/Source/Services/ZilliqaService+Rx/DefaultZilliqaService.swift
+++ b/Source/Services/ZilliqaService+Rx/DefaultZilliqaService.swift
@@ -23,7 +23,7 @@ public final class DefaultZilliqaService: ZilliqaService, ReactiveCompatible {
 
 public extension DefaultZilliqaService {
 
-    func getBalalance(for address: Address, done: @escaping Done<BalanceResponse>) -> Void {
+    func getBalance(for address: Address, done: @escaping Done<BalanceResponse>) -> Void {
         return apiClient.send(request: BalanceRequest(address: address), done: done)
     }
 

--- a/Source/Services/ZilliqaService+Rx/Polling.swift
+++ b/Source/Services/ZilliqaService+Rx/Polling.swift
@@ -12,7 +12,7 @@ public struct Polling {
     public let count: Count
     public let backoff: Backoff
     public let initialDelay: Delay
-
+    
     public init(_ count: Count, backoff: Backoff, initialDelay: Delay) {
         self.count = count
         self.backoff = backoff
@@ -27,11 +27,11 @@ public extension Polling {
                        initialDelay: .oneSecond
         )
     }
-
+    
     public enum Backoff {
         case linearIncrement(of: Delay)
     }
-
+    
     public enum Delay: Int {
         case oneSecond = 1
         case twoSeconds = 2
@@ -39,8 +39,9 @@ public extension Polling {
         case fiveSeconds = 5
         case sevenSeconds = 7
         case tenSeconds = 10
+        case twentySeconds = 20
     }
-
+    
     public enum Count: Int {
         case once = 1
         case twice = 2
@@ -51,59 +52,11 @@ public extension Polling {
     }
 }
 
-public extension ZilliqaService {
-    func hasNetworkReachedConsensusYetForTransactionWith(id: String, polling: Polling, done: @escaping Done<TransactionReceipt>) {
-        let start = DispatchTime.now()
-
-        func fetch(retriesLeft: Int, waitUntilCall delayInSeconds: Int) {
-            print("\nfetch - retriesLeft: \(retriesLeft), delayInSeconds: \(delayInSeconds)")
-            let delay = DispatchTimeInterval.seconds(delayInSeconds)
-
-            func printElapsedTime() {
-                let end = DispatchTime.now()
-                let timeInterval = Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000 // Technically could overflow for long running tests
-                print("took: \(timeInterval)s, using: \(polling.count.rawValue - retriesLeft) polls")
-            }
-
-            background(delay: delay) { [unowned self] in
-                self.getStatusOfTransaction(id: id) {
-                    if case .success(let status) = $0, case let receipt = status.receipt, receipt.isSent {
-                        printElapsedTime()
-                        return done(
-                            .success(
-                                TransactionReceipt(id: id, totalGasCost: receipt.totalGasCost)
-                            )
-                        )
-                    }
-
-                    // Stop recursion with failure when retry count reached zero
-                    guard retriesLeft > 0 else {
-                        printElapsedTime()
-                        return done(.failure(Error.api(.timeout)))
-                    }
-
-                    // Recursivly call self
-                    let increasedDelay: Int
-                    switch polling.backoff {
-                    case .linearIncrement(let delayIncrement):
-                        increasedDelay = delayInSeconds + delayIncrement.rawValue
-                    }
-
-                    fetch(retriesLeft: retriesLeft - 1, waitUntilCall: increasedDelay)
-                }
-            }
+extension Polling.Backoff {
+    func add(to delayInSeconds: Int) -> Int {
+        switch self {
+        case .linearIncrement(let delayIncrement):
+            return delayInSeconds + delayIncrement.rawValue
         }
-
-        // initial
-        fetch(retriesLeft: polling.count.rawValue, waitUntilCall: polling.initialDelay.rawValue)
-    }
-}
-
-private extension ZilliqaService {
-    func getStatusOfTransaction(id: String, done: @escaping Done<StatusOfTransactionResponse>) {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "HH:mm:ss"
-        print("\(dateFormatter.string(from: Date())) - Checking status of tx: \(id)")
-        return apiClient.send(request: StatusOfTransactionRequest(transactionId: id), done: done)
     }
 }

--- a/Source/Services/ZilliqaService+Rx/Polling.swift
+++ b/Source/Services/ZilliqaService+Rx/Polling.swift
@@ -1,0 +1,68 @@
+//
+//  Polling.swift
+//  Zesame
+//
+//  Created by Alexander Cyon on 2018-12-11.
+//  Copyright © 2018 Open Zesame. All rights reserved.
+//
+
+import Foundation
+
+public struct Polling {
+    public let count: Count
+    public let backoff: Backoff
+    public let initialDelay: Delay
+
+    public init(
+        _ count: Count = .tenTimes,
+        backoff: Backoff = .linearIncrement(of: .oneSecond),
+        initialDelay: Delay = .fiveSeconds) {
+        self.count = count
+        self.backoff = backoff
+        self.initialDelay = initialDelay
+    }
+}
+
+public extension Polling {
+    static var tenTimesLinearBackoff: Polling {
+        return Polling(.tenTimes,
+                       backoff: .linearIncrement(of: .oneSecond),
+                       initialDelay: .fiveSeconds
+        )
+    }
+
+    public enum Backoff {
+        case linearIncrement(of: Delay)
+    }
+
+    public enum Delay: TimeInterval {
+        case oneSecond
+        case threeSeconds = 3
+        case fiveSeconds = 5
+        case sevenSeconds = 7
+        case tenSeconds = 10
+    }
+
+    public enum Count: Int {
+        case once = 1
+        case twice = 2
+        case threeTimes = 3
+        case fiveTimes = 5
+        case tenTimes = 10
+    }
+}
+
+extension ZilliqaService {
+    func statusOfTransaction(id: String, polling: Polling = .tenTimesLinearBackoff, done: @escaping Done<StatusOfTransactionResponse>) {
+
+        let startDelay = DispatchTimeInterval.seconds(Int(polling.initialDelay.rawValue))
+
+        background(delay: startDelay) { [unowned self] in
+            return self.getStatusOfTransaction(id: id, done: done)
+        }
+    }
+
+    private func getStatusOfTransaction(id: String, done: @escaping Done<StatusOfTransactionResponse>) {
+        return apiClient.send(request: StatusOfTransactionRequest(transactionId: id), done: done)
+    }
+}

--- a/Source/Services/ZilliqaService+Rx/Polling.swift
+++ b/Source/Services/ZilliqaService+Rx/Polling.swift
@@ -13,10 +13,7 @@ public struct Polling {
     public let backoff: Backoff
     public let initialDelay: Delay
 
-    public init(
-        _ count: Count = .tenTimes,
-        backoff: Backoff = .linearIncrement(of: .oneSecond),
-        initialDelay: Delay = .fiveSeconds) {
+    public init(_ count: Count, backoff: Backoff, initialDelay: Delay) {
         self.count = count
         self.backoff = backoff
         self.initialDelay = initialDelay
@@ -24,10 +21,10 @@ public struct Polling {
 }
 
 public extension Polling {
-    static var tenTimesLinearBackoff: Polling {
-        return Polling(.tenTimes,
-                       backoff: .linearIncrement(of: .oneSecond),
-                       initialDelay: .fiveSeconds
+    static var twentyTimesLinearBackoff: Polling {
+        return Polling(.twentyTimes,
+                       backoff: .linearIncrement(of: .twoSeconds),
+                       initialDelay: .oneSecond
         )
     }
 
@@ -35,8 +32,9 @@ public extension Polling {
         case linearIncrement(of: Delay)
     }
 
-    public enum Delay: TimeInterval {
-        case oneSecond
+    public enum Delay: Int {
+        case oneSecond = 1
+        case twoSeconds = 2
         case threeSeconds = 3
         case fiveSeconds = 5
         case sevenSeconds = 7
@@ -49,20 +47,63 @@ public extension Polling {
         case threeTimes = 3
         case fiveTimes = 5
         case tenTimes = 10
+        case twentyTimes = 20
     }
 }
 
-extension ZilliqaService {
-    func statusOfTransaction(id: String, polling: Polling = .tenTimesLinearBackoff, done: @escaping Done<StatusOfTransactionResponse>) {
+public extension ZilliqaService {
+    func hasNetworkReachedConsensusYetForTransactionWith(id: String, polling: Polling, done: @escaping Done<TransactionReceipt>) {
+        let start = DispatchTime.now()
 
-        let startDelay = DispatchTimeInterval.seconds(Int(polling.initialDelay.rawValue))
+        func fetch(retriesLeft: Int, waitUntilCall delayInSeconds: Int) {
+            print("\nfetch - retriesLeft: \(retriesLeft), delayInSeconds: \(delayInSeconds)")
+            let delay = DispatchTimeInterval.seconds(delayInSeconds)
 
-        background(delay: startDelay) { [unowned self] in
-            return self.getStatusOfTransaction(id: id, done: done)
+            func printElapsedTime() {
+                let end = DispatchTime.now()
+                let timeInterval = Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000 // Technically could overflow for long running tests
+                print("took: \(timeInterval)s, using: \(polling.count.rawValue - retriesLeft) polls")
+            }
+
+            background(delay: delay) { [unowned self] in
+                self.getStatusOfTransaction(id: id) {
+                    if case .success(let status) = $0, case let receipt = status.receipt, receipt.isSent {
+                        printElapsedTime()
+                        return done(
+                            .success(
+                                TransactionReceipt(id: id, totalGasCost: receipt.totalGasCost)
+                            )
+                        )
+                    }
+
+                    // Stop recursion with failure when retry count reached zero
+                    guard retriesLeft > 0 else {
+                        printElapsedTime()
+                        return done(.failure(Error.api(.timeout)))
+                    }
+
+                    // Recursivly call self
+                    let increasedDelay: Int
+                    switch polling.backoff {
+                    case .linearIncrement(let delayIncrement):
+                        increasedDelay = delayInSeconds + delayIncrement.rawValue
+                    }
+
+                    fetch(retriesLeft: retriesLeft - 1, waitUntilCall: increasedDelay)
+                }
+            }
         }
-    }
 
-    private func getStatusOfTransaction(id: String, done: @escaping Done<StatusOfTransactionResponse>) {
+        // initial
+        fetch(retriesLeft: polling.count.rawValue, waitUntilCall: polling.initialDelay.rawValue)
+    }
+}
+
+private extension ZilliqaService {
+    func getStatusOfTransaction(id: String, done: @escaping Done<StatusOfTransactionResponse>) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "HH:mm:ss"
+        print("\(dateFormatter.string(from: Date())) - Checking status of tx: \(id)")
         return apiClient.send(request: StatusOfTransactionRequest(transactionId: id), done: done)
     }
 }

--- a/Source/Services/ZilliqaService+Rx/Rx+ZilliqaService.swift
+++ b/Source/Services/ZilliqaService+Rx/Rx+ZilliqaService.swift
@@ -17,6 +17,12 @@ import EllipticCurveKit
 extension Reactive: ZilliqaServiceReactive where Base: ZilliqaService {}
 public extension Reactive where Base: ZilliqaService {
 
+    func hasNetworkReachedConsensusYetForTransactionWith(id: String, polling: Polling) -> Observable<TransactionReceipt> {
+        return callBase {
+            $0.hasNetworkReachedConsensusYetForTransactionWith(id: id, polling: polling, done: $1)
+        }
+    }
+
     func verifyThat(encryptionPasshrase: String, canDecryptKeystore keystore: Keystore) -> Observable<Bool> {
         return callBase {
             $0.verifyThat(encryptionPasshrase: encryptionPasshrase, canDecryptKeystore: keystore, done: $1)

--- a/Source/Services/ZilliqaService+Rx/Rx+ZilliqaService.swift
+++ b/Source/Services/ZilliqaService+Rx/Rx+ZilliqaService.swift
@@ -43,7 +43,7 @@ public extension Reactive where Base: (ZilliqaService & AnyObject) {
 
     func getBalance(for address: Address) -> Observable<BalanceResponse> {
         return callBase {
-            $0.getBalalance(for: address, done: $1)
+            $0.getBalance(for: address, done: $1)
         }
     }
 

--- a/Source/Services/ZilliqaService+Rx/Rx+ZilliqaService.swift
+++ b/Source/Services/ZilliqaService+Rx/Rx+ZilliqaService.swift
@@ -14,8 +14,8 @@ import APIKit
 import Result
 import EllipticCurveKit
 
-extension Reactive: ZilliqaServiceReactive where Base: (ZilliqaService & AnyObject) {}
-public extension Reactive where Base: (ZilliqaService & AnyObject) {
+extension Reactive: ZilliqaServiceReactive where Base: ZilliqaService {}
+public extension Reactive where Base: ZilliqaService {
 
     func verifyThat(encryptionPasshrase: String, canDecryptKeystore keystore: Keystore) -> Observable<Bool> {
         return callBase {

--- a/Source/Services/ZilliqaService+Rx/ZilliqaService+PollTransaction.swift
+++ b/Source/Services/ZilliqaService+Rx/ZilliqaService+PollTransaction.swift
@@ -1,0 +1,43 @@
+//
+//  ZilliqaService+PollTransaction.swift
+//  Zesame
+//
+//  Created by Alexander Cyon on 2018-12-12.
+//  Copyright © 2018 Open Zesame. All rights reserved.
+//
+
+import Foundation
+
+public extension ZilliqaService {
+    func hasNetworkReachedConsensusYetForTransactionWith(id: String, polling: Polling, done: @escaping Done<TransactionReceipt>) {
+        func poll(retriesLeft: Int, delay delayInSeconds: Int) {
+            // Stop recursion with failure when retry count reached zero
+            guard retriesLeft > 0 else {
+                return done(.failure(Error.api(.timeout)))
+            }
+
+            let delay = DispatchTimeInterval.seconds(delayInSeconds)
+
+            background(delay: delay) { [unowned self] in
+                self.getStatusOfTransaction(id: id) {
+                    if case .success(let pollResponse) = $0, let receipt = TransactionReceipt(for: id, pollResponse: pollResponse) {
+                        return done(.success(receipt))
+                    }
+
+                    // Recursivly call self
+                    poll(retriesLeft: retriesLeft - 1, delay: polling.backoff.add(to: delayInSeconds))
+                }
+            }
+        }
+
+        // Initiate recursive backing off polling
+        poll(retriesLeft: polling.count.rawValue, delay: polling.initialDelay.rawValue)
+    }
+}
+
+// MARK: - Private
+private extension ZilliqaService {
+    func getStatusOfTransaction(id: String, done: @escaping Done<StatusOfTransactionResponse>) {
+        return apiClient.send(request: StatusOfTransactionRequest(transactionId: id), done: done)
+    }
+}

--- a/Source/Services/ZilliqaService+Rx/ZilliqaService.swift
+++ b/Source/Services/ZilliqaService+Rx/ZilliqaService.swift
@@ -22,7 +22,7 @@ public protocol ZilliqaService {
     func restoreWallet(from restoration: KeyRestoration, done: @escaping Done<Wallet>)
     func exportKeystore(address: Address, privateKey: PrivateKey, encryptWalletBy passphrase: String, done: @escaping Done<Keystore>)
 
-    func getBalalance(for address: Address, done: @escaping Done<BalanceResponse>)
+    func getBalance(for address: Address, done: @escaping Done<BalanceResponse>)
     func send(transaction: SignedTransaction, done: @escaping Done<TransactionResponse>)
 }
 

--- a/Source/Services/ZilliqaService+Rx/ZilliqaService.swift
+++ b/Source/Services/ZilliqaService+Rx/ZilliqaService.swift
@@ -14,7 +14,7 @@ import APIKit
 import RxSwift
 import CryptoSwift
 
-public protocol ZilliqaService {
+public protocol ZilliqaService: AnyObject {
     var apiClient: APIClient { get }
 
     func verifyThat(encryptionPasshrase: String, canDecryptKeystore: Keystore, done: @escaping Done<Bool>)

--- a/Source/Services/ZilliqaService+Rx/ZilliqaService.swift
+++ b/Source/Services/ZilliqaService+Rx/ZilliqaService.swift
@@ -36,4 +36,12 @@ public protocol ZilliqaServiceReactive {
     func getBalance(for address: Address) -> Observable<BalanceResponse>
     func sendTransaction(for payment: Payment, keystore: Keystore, passphrase: String) -> Observable<TransactionResponse>
     func sendTransaction(for payment: Payment, signWith keyPair: KeyPair) -> Observable<TransactionResponse>
+
+    func hasNetworkReachedConsensusYetForTransactionWith(id: String, polling: Polling) -> Observable<TransactionReceipt>
+}
+
+public extension ZilliqaServiceReactive {
+    func hasNetworkReachedConsensusYetForTransactionWith(id: String) -> Observable<TransactionReceipt> {
+        return hasNetworkReachedConsensusYetForTransactionWith(id: id, polling: .twentyTimesLinearBackoff)
+    }
 }

--- a/Zesame.xcodeproj/project.pbxproj
+++ b/Zesame.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		48196F242157C480009C40BB /* Scrypt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48196F222157C480009C40BB /* Scrypt.swift */; };
 		48196F262157C574009C40BB /* ZilliqaService+DefaultImplementations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48196F252157C574009C40BB /* ZilliqaService+DefaultImplementations.swift */; };
 		48196F272157C574009C40BB /* ZilliqaService+DefaultImplementations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48196F252157C574009C40BB /* ZilliqaService+DefaultImplementations.swift */; };
+		4819BD9021C0DBD900443F2A /* ZilliqaService+PollTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4819BD8F21C0DBD900443F2A /* ZilliqaService+PollTransaction.swift */; };
+		4819BD9121C0DBD900443F2A /* ZilliqaService+PollTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4819BD8F21C0DBD900443F2A /* ZilliqaService+PollTransaction.swift */; };
 		483460A82145BD4A007E5D5C /* ZilliqaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483460A72145BD4A007E5D5C /* ZilliqaService.swift */; };
 		483460A92145BD4C007E5D5C /* ZilliqaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483460A72145BD4A007E5D5C /* ZilliqaService.swift */; };
 		483F0F7C2146F9FA00E6EE08 /* Rx+ZilliqaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483F0F7B2146F9FA00E6EE08 /* Rx+ZilliqaService.swift */; };
@@ -209,6 +211,7 @@
 		481169A421677CC300341F81 /* AddressChecksumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressChecksumTests.swift; sourceTree = "<group>"; };
 		48196F222157C480009C40BB /* Scrypt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrypt.swift; sourceTree = "<group>"; };
 		48196F252157C574009C40BB /* ZilliqaService+DefaultImplementations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZilliqaService+DefaultImplementations.swift"; sourceTree = "<group>"; };
+		4819BD8F21C0DBD900443F2A /* ZilliqaService+PollTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZilliqaService+PollTransaction.swift"; sourceTree = "<group>"; };
 		483460A22145BD28007E5D5C /* JSONRPCKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JSONRPCKit.framework; path = Carthage/Build/iOS/JSONRPCKit.framework; sourceTree = "<group>"; };
 		483460A32145BD28007E5D5C /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/iOS/Result.framework; sourceTree = "<group>"; };
 		483460A72145BD4A007E5D5C /* ZilliqaService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZilliqaService.swift; sourceTree = "<group>"; };
@@ -541,6 +544,7 @@
 				488A65862155ACD20091FD03 /* ZilliqaService+Signing.swift */,
 				483F0F7B2146F9FA00E6EE08 /* Rx+ZilliqaService.swift */,
 				4877B50721BFBB8900A94318 /* Polling.swift */,
+				4819BD8F21C0DBD900443F2A /* ZilliqaService+PollTransaction.swift */,
 			);
 			path = "ZilliqaService+Rx";
 			sourceTree = "<group>";
@@ -899,6 +903,7 @@
 				4877B4E521BE2EFA00A94318 /* Wallet+Codable.swift in Sources */,
 				4877B4E321BE2EFA00A94318 /* Address+Codable.swift in Sources */,
 				488A65882155ACD20091FD03 /* ZilliqaService+Signing.swift in Sources */,
+				4819BD9121C0DBD900443F2A /* ZilliqaService+PollTransaction.swift in Sources */,
 				4877B4DD21BE2EFA00A94318 /* Address.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -961,6 +966,7 @@
 				4877B4E421BE2EFA00A94318 /* Wallet+Codable.swift in Sources */,
 				4877B4E221BE2EFA00A94318 /* Address+Codable.swift in Sources */,
 				488A65872155ACD20091FD03 /* ZilliqaService+Signing.swift in Sources */,
+				4819BD9021C0DBD900443F2A /* ZilliqaService+PollTransaction.swift in Sources */,
 				4877B4DC21BE2EFA00A94318 /* Address.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Zesame.xcodeproj/project.pbxproj
+++ b/Zesame.xcodeproj/project.pbxproj
@@ -84,6 +84,10 @@
 		4877B4F221BE495500A94318 /* messages.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4877B4F021BE495500A94318 /* messages.pb.swift */; };
 		4877B4F421BE839C00A94318 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4877B4F321BE839C00A94318 /* SwiftProtobuf.framework */; };
 		4877B4FB21BE8CD200A94318 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4877B4FA21BE8CD200A94318 /* SwiftProtobuf.framework */; };
+		4877B50221BFA89400A94318 /* StatusOfTransactionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4877B50121BFA89400A94318 /* StatusOfTransactionRequest.swift */; };
+		4877B50321BFA89400A94318 /* StatusOfTransactionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4877B50121BFA89400A94318 /* StatusOfTransactionRequest.swift */; };
+		4877B50821BFBB8900A94318 /* Polling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4877B50721BFBB8900A94318 /* Polling.swift */; };
+		4877B50921BFBB8900A94318 /* Polling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4877B50721BFBB8900A94318 /* Polling.swift */; };
 		48802CDB21751A32003A22FD /* RxTest.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 48B5B2FB2148321500147005 /* RxTest.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		48802CDD21751A32003A22FD /* RxSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 483F0F7F2146FB8D00E6EE08 /* RxSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		48802CDE21751A32003A22FD /* APIKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 483460AA2145C182007E5D5C /* APIKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -257,6 +261,8 @@
 		4877B4F021BE495500A94318 /* messages.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = messages.pb.swift; sourceTree = "<group>"; };
 		4877B4F321BE839C00A94318 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftProtobuf.framework; path = Carthage/Build/iOS/SwiftProtobuf.framework; sourceTree = "<group>"; };
 		4877B4FA21BE8CD200A94318 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftProtobuf.framework; path = Carthage/Build/Mac/SwiftProtobuf.framework; sourceTree = "<group>"; };
+		4877B50121BFA89400A94318 /* StatusOfTransactionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusOfTransactionRequest.swift; sourceTree = "<group>"; };
+		4877B50721BFBB8900A94318 /* Polling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Polling.swift; sourceTree = "<group>"; };
 		48802CE421751AB7003A22FD /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/Mac/Result.framework; sourceTree = "<group>"; };
 		48802CE521751AB7003A22FD /* APIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = APIKit.framework; path = Carthage/Build/Mac/APIKit.framework; sourceTree = "<group>"; };
 		48802CE621751AB7003A22FD /* JSONRPCKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JSONRPCKit.framework; path = Carthage/Build/Mac/JSONRPCKit.framework; sourceTree = "<group>"; };
@@ -534,6 +540,7 @@
 				48196F252157C574009C40BB /* ZilliqaService+DefaultImplementations.swift */,
 				488A65862155ACD20091FD03 /* ZilliqaService+Signing.swift */,
 				483F0F7B2146F9FA00E6EE08 /* Rx+ZilliqaService.swift */,
+				4877B50721BFBB8900A94318 /* Polling.swift */,
 			);
 			path = "ZilliqaService+Rx";
 			sourceTree = "<group>";
@@ -542,6 +549,7 @@
 			isa = PBXGroup;
 			children = (
 				48D4114E2147205200E2F207 /* TransactionRequest.swift */,
+				4877B50121BFA89400A94318 /* StatusOfTransactionRequest.swift */,
 				48A64009218645F300B08C67 /* TransactionResponse.swift */,
 				484E09E921543F3B003D928E /* MessageFromUnsignedTransaction.swift */,
 			);
@@ -864,11 +872,13 @@
 				488A658C2157A1670091FD03 /* DispatchQueue+Sugar.swift in Sources */,
 				4877B4C721BE2EFA00A94318 /* KeyRestoration.swift in Sources */,
 				4877B4D721BE2EFA00A94318 /* Keystore+Wallet+Export.swift in Sources */,
+				4877B50921BFBB8900A94318 /* Polling.swift in Sources */,
 				484E09EB21543F43003D928E /* MessageFromUnsignedTransaction.swift in Sources */,
 				4877B4D921BE2EFA00A94318 /* Nonce.swift in Sources */,
 				4877B4D521BE2EFA00A94318 /* Keystore+Wallet+Import.swift in Sources */,
 				4877B4DB21BE2EFA00A94318 /* Address+CustomStringConvertible.swift in Sources */,
 				483F0F942147085500E6EE08 /* BalanceResponse.swift in Sources */,
+				4877B50321BFA89400A94318 /* StatusOfTransactionRequest.swift in Sources */,
 				483F0F8C214704D700E6EE08 /* Error.swift in Sources */,
 				4877B4E721BE2EFA00A94318 /* Wallet+Decrypt.swift in Sources */,
 				4877B4E121BE2EFA00A94318 /* Address+HexString.swift in Sources */,
@@ -924,11 +934,13 @@
 				488A658B2157A1670091FD03 /* DispatchQueue+Sugar.swift in Sources */,
 				4877B4C621BE2EFA00A94318 /* KeyRestoration.swift in Sources */,
 				4877B4D621BE2EFA00A94318 /* Keystore+Wallet+Export.swift in Sources */,
+				4877B50821BFBB8900A94318 /* Polling.swift in Sources */,
 				484E09EA21543F3B003D928E /* MessageFromUnsignedTransaction.swift in Sources */,
 				4877B4D821BE2EFA00A94318 /* Nonce.swift in Sources */,
 				4877B4D421BE2EFA00A94318 /* Keystore+Wallet+Import.swift in Sources */,
 				4877B4DA21BE2EFA00A94318 /* Address+CustomStringConvertible.swift in Sources */,
 				483F0F932147085500E6EE08 /* BalanceResponse.swift in Sources */,
+				4877B50221BFA89400A94318 /* StatusOfTransactionRequest.swift in Sources */,
 				48A6400A218645F300B08C67 /* TransactionResponse.swift in Sources */,
 				4877B4E621BE2EFA00A94318 /* Wallet+Decrypt.swift in Sources */,
 				4877B4E021BE2EFA00A94318 /* Address+HexString.swift in Sources */,


### PR DESCRIPTION
Introducing polling of transaction status, to see if the transaction was "successful". By reading the `receipt`'s boolean property named `success`.  The method has been named `hasNetworkReachedConsensusYetForTransactionWith:id:polling` but might be misleading since it might not be true that it means that the network actually has reached consensus. But will stick with that name for now