### PR TITLE
Update copyright year range to 2018-2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/BigNumber/BigNumber.swift
+++ b/Sources/Zesame/BigNumber/BigNumber.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/BigNumber/BigUInt+String+Init.swift
+++ b/Sources/Zesame/BigNumber/BigUInt+String+Init.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Cryptography/DerivedKey.swift
+++ b/Sources/Zesame/Cryptography/DerivedKey.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Cryptography/SecureRandom.swift
+++ b/Sources/Zesame/Cryptography/SecureRandom.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Extensions/Data+Hex.swift
+++ b/Sources/Zesame/Extensions/Data+Hex.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Extensions/DataConvertible.swift
+++ b/Sources/Zesame/Extensions/DataConvertible.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Extensions/Encodable+Dictionary.swift
+++ b/Sources/Zesame/Extensions/Encodable+Dictionary.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Extensions/String+AmountValidation.swift
+++ b/Sources/Zesame/Extensions/String+AmountValidation.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/AmountError.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/AmountError.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Bound.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Bound.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Lowerbound/AdjustableLowerbound.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Lowerbound/AdjustableLowerbound.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Lowerbound/AnyLowerbound.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Lowerbound/AnyLowerbound.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Lowerbound/Lowerbound.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Lowerbound/Lowerbound.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Uppperbound/AdjustableUpperbound.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Uppperbound/AdjustableUpperbound.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Uppperbound/AnyUpperbound.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Uppperbound/AnyUpperbound.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Uppperbound/Upperbound.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Bound/Uppperbound/Upperbound.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Unbound/NoLowerbound.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Unbound/NoLowerbound.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Unbound/NoUpperbound.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Unbound/NoUpperbound.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Unbound/Unbound.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Bound/Unbound/Unbound.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Arithmetic.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Arithmetic.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Bound.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Bound.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Codable.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Codable.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Comparable.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Comparable.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Compare+Heterogeneous.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Compare+Heterogeneous.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+CustomDebugStringConvertible.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+CustomDebugStringConvertible.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Unbound.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Unbound.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+UnitConversion.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+UnitConversion.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Validate.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount+Validate.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/ExpressibleByAmount.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Units/Double+Zil_Li_Qa.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Units/Double+Zil_Li_Qa.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Units/Li.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Units/Li.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Units/Qa.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Units/Qa.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Units/Unit.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Units/Unit.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/ExpressibleByAmount/Units/Zil.swift
+++ b/Sources/Zesame/Models/Manual/ExpressibleByAmount/Units/Zil.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/KeyRestoration.swift
+++ b/Sources/Zesame/Models/Manual/KeyRestoration.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Payment/Amount.swift
+++ b/Sources/Zesame/Models/Manual/Payment/Amount.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Payment/GasLimit.swift
+++ b/Sources/Zesame/Models/Manual/Payment/GasLimit.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Payment/GasPrice.swift
+++ b/Sources/Zesame/Models/Manual/Payment/GasPrice.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Payment/Network.swift
+++ b/Sources/Zesame/Models/Manual/Payment/Network.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Payment/Payment.swift
+++ b/Sources/Zesame/Models/Manual/Payment/Payment.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Payment/SignedTransaction.swift
+++ b/Sources/Zesame/Models/Manual/Payment/SignedTransaction.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Payment/Transaction.swift
+++ b/Sources/Zesame/Models/Manual/Payment/Transaction.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Payment/Version.swift
+++ b/Sources/Zesame/Models/Manual/Payment/Version.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Payment/ZilliqaAPIEndpoint.swift
+++ b/Sources/Zesame/Models/Manual/Payment/ZilliqaAPIEndpoint.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Protocols/StringConvertible.swift
+++ b/Sources/Zesame/Models/Manual/Protocols/StringConvertible.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/Address/Address+ExpressibleByStringLiteral.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/Address/Address+ExpressibleByStringLiteral.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/Address/Address+Validation+Error.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/Address/Address+Validation+Error.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/Address/Address.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/Address/Address.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/AddressChecksummedConvertible/AddressChecksummedConvertible.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/AddressChecksummedConvertible/AddressChecksummedConvertible.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/Bech32/Bech32.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/Bech32/Bech32.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/Bech32/Bech32Address.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/Bech32/Bech32Address.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/HexString/HexString+HexStringConvertible.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/HexString/HexString+HexStringConvertible.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/HexString/HexString.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/HexString/HexString.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/HexString/HexStringConvertible+Validation.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/HexString/HexStringConvertible+Validation.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/HexString/HexStringConvertible.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/HexString/HexStringConvertible.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/LegacyAddress/LegacyAddress+Codable.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/LegacyAddress/LegacyAddress+Codable.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/LegacyAddress/LegacyAddress+Validation.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/LegacyAddress/LegacyAddress+Validation.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Address/LegacyAddress/LegacyAddress.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Address/LegacyAddress/LegacyAddress.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/KeyPair.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/KeyPair.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Keystore/AnyKeyDeriving.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Keystore/AnyKeyDeriving.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Keystore/KeyDerivationFunction.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Keystore/KeyDerivationFunction.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Keystore/KeyDerivationFunctionParameters.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Keystore/KeyDerivationFunctionParameters.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Keystore/KeyDeriving.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Keystore/KeyDeriving.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Keystore/Keystore+Crypto.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Keystore/Keystore+Crypto.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Keystore/Keystore+KeyDeriving.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Keystore/Keystore+KeyDeriving.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Keystore/Keystore+Wallet+Export.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Keystore/Keystore+Wallet+Export.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Keystore/Keystore+Wallet+Import.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Keystore/Keystore+Wallet+Import.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Keystore/Keystore.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Keystore/Keystore.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Nonce.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Nonce.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Wallet/Wallet+Codable.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Wallet/Wallet+Codable.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Wallet/Wallet+CustomStringConvertible.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Wallet/Wallet+CustomStringConvertible.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Wallet/Wallet+Decrypt.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Wallet/Wallet+Decrypt.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Models/Manual/Wallet/Wallet/Wallet.swift
+++ b/Sources/Zesame/Models/Manual/Wallet/Wallet/Wallet.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/APIClient/APIClient.swift
+++ b/Sources/Zesame/Networking/APIClient/APIClient.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/APIClient/DefaultAPIClient.swift
+++ b/Sources/Zesame/Networking/APIClient/DefaultAPIClient.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/RPCError.swift
+++ b/Sources/Zesame/Networking/JSONRPC/RPCError.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/RPCMethod.swift
+++ b/Sources/Zesame/Networking/JSONRPC/RPCMethod.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/RPCRequest.swift
+++ b/Sources/Zesame/Networking/JSONRPC/RPCRequest.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/RPCRequestIdGenerator.swift
+++ b/Sources/Zesame/Networking/JSONRPC/RPCRequestIdGenerator.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/RPCResponse.swift
+++ b/Sources/Zesame/Networking/JSONRPC/RPCResponse.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/RPCResponseSuccess.swift
+++ b/Sources/Zesame/Networking/JSONRPC/RPCResponseSuccess.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/Responses/Balance/BalanceResponse.swift
+++ b/Sources/Zesame/Networking/JSONRPC/Responses/Balance/BalanceResponse.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/Responses/Transaction/MessageFromUnsignedTransaction.swift
+++ b/Sources/Zesame/Networking/JSONRPC/Responses/Transaction/MessageFromUnsignedTransaction.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/Responses/Transaction/StatusOfTransactionResponse+Receipt.swift
+++ b/Sources/Zesame/Networking/JSONRPC/Responses/Transaction/StatusOfTransactionResponse+Receipt.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/Responses/Transaction/StatusOfTransactionResponse.swift
+++ b/Sources/Zesame/Networking/JSONRPC/Responses/Transaction/StatusOfTransactionResponse.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/Responses/Transaction/TransactionReceipt.swift
+++ b/Sources/Zesame/Networking/JSONRPC/Responses/Transaction/TransactionReceipt.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/Responses/Transaction/TransactionResponse.swift
+++ b/Sources/Zesame/Networking/JSONRPC/Responses/Transaction/TransactionResponse.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Networking/JSONRPC/Responses/ZilliqaNetworkID/NetworkResponse.swift
+++ b/Sources/Zesame/Networking/JSONRPC/Responses/ZilliqaNetworkID/NetworkResponse.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Services/Combine+ZilliqaService.swift
+++ b/Sources/Zesame/Services/Combine+ZilliqaService.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Services/DefaultZilliqaService.swift
+++ b/Sources/Zesame/Services/DefaultZilliqaService.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Services/Error.swift
+++ b/Sources/Zesame/Services/Error.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Services/Polling.swift
+++ b/Sources/Zesame/Services/Polling.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Services/ZilliqaService+DefaultImplementations.swift
+++ b/Sources/Zesame/Services/ZilliqaService+DefaultImplementations.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Services/ZilliqaService+PollTransaction.swift
+++ b/Sources/Zesame/Services/ZilliqaService+PollTransaction.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Services/ZilliqaService+Signing.swift
+++ b/Sources/Zesame/Services/ZilliqaService+Signing.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Zesame/Services/ZilliqaService.swift
+++ b/Sources/Zesame/Services/ZilliqaService.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/AddressChecksumTests.swift
+++ b/Tests/ZesameTests/AddressChecksumTests.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/AddressValidationTests.swift
+++ b/Tests/ZesameTests/AddressValidationTests.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/AmountFromStringContainingWhitespaces.swift
+++ b/Tests/ZesameTests/AmountFromStringContainingWhitespaces.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/BalanceResponseJSONTests.swift
+++ b/Tests/ZesameTests/BalanceResponseJSONTests.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/Bech32Tests.swift
+++ b/Tests/ZesameTests/Bech32Tests.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/ExportKeystoreTests.swift
+++ b/Tests/ZesameTests/ExportKeystoreTests.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/ExpressibleByAmountToStringTests.swift
+++ b/Tests/ZesameTests/ExpressibleByAmountToStringTests.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/GasPriceTests.swift
+++ b/Tests/ZesameTests/GasPriceTests.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/Helpers/XCTest+Helpers.swift
+++ b/Tests/ZesameTests/Helpers/XCTest+Helpers.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/KeyStoreImportExportTests.swift
+++ b/Tests/ZesameTests/KeyStoreImportExportTests.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/StringCommaSeparatorFunctionsTests.swift
+++ b/Tests/ZesameTests/StringCommaSeparatorFunctionsTests.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/TransactionCostTests.swift
+++ b/Tests/ZesameTests/TransactionCostTests.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/TransactionSigningTests.swift
+++ b/Tests/ZesameTests/TransactionSigningTests.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Tests/ZesameTests/UnitConversionTests.swift
+++ b/Tests/ZesameTests/UnitConversionTests.swift
@@ -1,7 +1,7 @@
 //
 // MIT License
 //
-// Copyright (c) 2018-2019 Open Zesame (https://github.com/OpenZesame)
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Update copyright headers from `2018-2019` to `2018-2026` across 110 Swift files and `LICENSE`.

## Test plan
- [x] Pre-commit hooks pass (typos, SwiftFormat, SwiftLint, Swift unit tests)
- [ ] CI green