### PR TITLE
ci: upload test coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,5 +63,30 @@ jobs:
           key: spm-${{ runner.os }}-xcode-${{ env.XCODE_BUILD }}-${{ hashFiles('**/Package.resolved') }}
           restore-keys: spm-${{ runner.os }}-xcode-${{ env.XCODE_BUILD }}-
 
-      - name: Build & test
-        run: swift test
+      - name: Build & test with coverage
+        run: swift test --enable-code-coverage
+
+      # ── 5. Coverage upload ─────────────────────────────────────────────────
+      # SPM packages don't produce an xcresult bundle, so we go straight from
+      # llvm-cov to lcov format — which Codecov ingests natively.
+      - name: Export coverage as lcov
+        run: |
+          PROFDATA=$(find .build -name 'default.profdata' | head -1)
+          TEST_BIN=$(find .build -name '*PackageTests.xctest' -print -quit)/Contents/MacOS/$(basename "$(find .build -name '*PackageTests.xctest' -print -quit)" .xctest)
+          mkdir -p .build
+          xcrun llvm-cov export \
+            -format=lcov \
+            -instr-profile "$PROFDATA" \
+            "$TEST_BIN" \
+            -ignore-filename-regex '(Tests|checkouts|debug/|release/|messages\.pb\.swift)' \
+            > .build/coverage.lcov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: .build/coverage.lcov
+          slug: OpenZesame/Zesame
+          # CODECOV_TOKEN must be added to the repo's Actions secrets.
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true


### PR DESCRIPTION
Mirrors SwiftIntro's coverage step but adapted for SPM (no xcresult
bundle): runs `swift test --enable-code-coverage`, then locates the
test binary and `default.profdata` and exports lcov format via
`xcrun llvm-cov export`. Codecov ingests lcov natively.

Tests, dependencies, and the auto-generated `messages.pb.swift` are
filtered out of the report so the metric reflects hand-written code
under `Sources/Zesame/`.

Requires `CODECOV_TOKEN` to be added to the repo's Actions secrets.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
