### PR TITLE
test: cover trap sites with swift-testing exit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,11 @@ jobs:
         run: swiftlint lint --force-exclude --strict --reporter github-actions-logging
 
       # ── 4. Build & Test ─────────────────────────────────────────────────────
+      - name: Select Xcode 16.3 (Swift 6.2)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.3'
+
       - name: Resolve Xcode build version
         run: echo "XCODE_BUILD=$(xcodebuild -version | tail -1 | awk '{print $NF}')" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
         run: swiftlint lint --force-exclude --strict --reporter github-actions-logging
 
       # ── 4. Build & Test ─────────────────────────────────────────────────────
-      - name: Select Xcode 16.3 (Swift 6.2)
+      - name: Select Xcode 26.0.1 (Swift 6.2)
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.3'
+          xcode-version: '26.0.1'
 
       - name: Resolve Xcode build version
         run: echo "XCODE_BUILD=$(xcodebuild -version | tail -1 | awk '{print $NF}')" >> "$GITHUB_ENV"

--- a/Tests/ZesameTests/ExitTrapTests.swift
+++ b/Tests/ZesameTests/ExitTrapTests.swift
@@ -22,8 +22,6 @@
 // SOFTWARE.
 //
 
-import BigInt
-import Foundation
 import Testing
 @testable import Zesame
 

--- a/Tests/ZesameTests/ExitTrapTests.swift
+++ b/Tests/ZesameTests/ExitTrapTests.swift
@@ -1,0 +1,89 @@
+//
+// MIT License
+//
+// Copyright (c) 2018-2026 Open Zesame (https://github.com/OpenZesame)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+import BigInt
+import Foundation
+import Testing
+@testable import Zesame
+
+/// Process-exit tests for the `fatalError` / `preconditionFailure` traps in the public API.
+/// Each `#expect(processExitsWith: .failure)` runs its closure in a child process and asserts the
+/// process terminates abnormally — this is the only way to drive coverage through `Never`-returning
+/// trap sites without crashing the host test runner.
+struct ExitTrapTests {
+    // MARK: - ExpressibleByAmount+Bound traps
+
+    @Test func amountValidInitTrapsOnOutOfBoundsMagnitude() async {
+        await #expect(processExitsWith: .failure) {
+            _ = Amount(valid: Amount.maxInQa + 1)
+        }
+    }
+
+    @Test func amountFloatLiteralTrapsOnOutOfBoundsValue() async {
+        await #expect(processExitsWith: .failure) {
+            _ = Amount(floatLiteral: -1.0)
+        }
+    }
+
+    @Test func amountIntegerLiteralTrapsOnOutOfBoundsValue() async {
+        await #expect(processExitsWith: .failure) {
+            _ = Amount(integerLiteral: -1)
+        }
+    }
+
+    @Test func amountStringLiteralTrapsOnNonNumericString() async {
+        await #expect(processExitsWith: .failure) {
+            _ = Amount(stringLiteral: "not-a-number")
+        }
+    }
+
+    // MARK: - GasPrice bounds traps
+
+    @Test func gasPriceMinSetterTrapsWhenAboveMax() async {
+        await #expect(processExitsWith: .failure) {
+            GasPrice.minInQa = GasPrice.maxInQa + 1
+        }
+    }
+
+    @Test func gasPriceMaxSetterTrapsWhenBelowMin() async {
+        await #expect(processExitsWith: .failure) {
+            GasPrice.maxInQa = GasPrice.minInQa - 1
+        }
+    }
+
+    // MARK: - HexString traps
+
+    @Test func hexStringChecksummedTrapsOnWrongLength() async {
+        await #expect(processExitsWith: .failure) {
+            guard let hex = try? HexString("ab") else { return }
+            _ = hex.checksummed
+        }
+    }
+
+    @Test func hexStringLiteralTrapsOnNonHex() async {
+        await #expect(processExitsWith: .failure) {
+            _ = HexString(stringLiteral: "zzzz")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 8 process-exit tests covering the public-API `fatalError` / `preconditionFailure` traps that are unreachable from the in-process test runner.
- Each test runs its body in a child process via `#expect(processExitsWith: .failure)` (Swift Testing 6.2+).

## Covered traps
- `ExpressibleByAmount+Bound`: `init(valid:)`, `floatLiteral`, `integerLiteral`, `stringLiteral`
- `GasPrice`: `minInQa` setter when above max, `maxInQa` setter when below min
- `HexString`: `.checksummed` on wrong-length input, `init(stringLiteral:)` on non-hex

## Not covered (genuinely unreachable from public API)
- `Bech32.swift:41` precondition (alphabet bytes are guaranteed ASCII by construction)
- `Address.swift:57` outer catch (the inner `do` only throws `Bech32.DecodingError`)
- `LegacyAddress.swift:82` `init(publicKey:)` (SHA-256 → suffix(20) is total)
- `Keystore+Wallet+Import.swift:62-69` AES.GCM SealedBox catch (already inside `coverage:exclude` markers; defensive)

## Test plan
- [x] `swift test --filter ExitTrapTests` — 8 tests pass locally
- [ ] CI green