### PR TITLE
CombineWrapper.callAsync: deliver values on the main run loop

### DIFF
--- a/Sources/Zesame/Services/Combine+ZilliqaService.swift
+++ b/Sources/Zesame/Services/Combine+ZilliqaService.swift
@@ -129,6 +129,21 @@ public extension CombineWrapper where Base: ZilliqaService {
     /// Bridges an async-throwing call into a `Future`-backed publisher whose failure is normalised
     /// to ``Zesame/Error``.
     ///
+    /// **Delivery scheduler:** values and errors are delivered on the **main
+    /// run loop**. The unstructured `Task { … }` below does *not* preserve
+    /// caller actor isolation (it inherits a nonisolated context), so the
+    /// `promise(.success/.failure)` call resumes on the cooperative thread
+    /// pool. Without an explicit hop, every UI consumer downstream would have
+    /// to add `.receive(on: DispatchQueue.main)` themselves *and* remember
+    /// that any `@MainActor`-isolated symbol they touch (e.g., a SwiftUI
+    /// state mutation, a UIKit binding, a `@MainActor` view-model method)
+    /// would trap on Swift 6's runtime isolation check (`_swift_task_check`-
+    /// `IsolatedSwift`) under iOS 26 / Swift 6.2. Hopping back to the main
+    /// run loop here makes the wrapper safe-by-default for the overwhelming
+    /// majority of consumers (UI apps); non-UI consumers pay one extra
+    /// scheduler hop, which is negligible compared to the network round-trip
+    /// the publisher's about to surface.
+    ///
     /// Subscriber cancellation propagates to the underlying `Task`, so subscribers tearing down a
     /// pipeline mid-flight don't leak the in-flight network call.
     private func callAsync<R>(
@@ -149,6 +164,7 @@ public extension CombineWrapper where Base: ZilliqaService {
             })
         }
         .handleEvents(receiveCancel: { box.cancel() })
+        .receive(on: DispatchQueue.main)
         .eraseToAnyPublisher()
     }
 }

--- a/Sources/Zesame/Services/Combine+ZilliqaService.swift
+++ b/Sources/Zesame/Services/Combine+ZilliqaService.swift
@@ -130,19 +130,20 @@ public extension CombineWrapper where Base: ZilliqaService {
     /// to ``Zesame/Error``.
     ///
     /// **Delivery scheduler:** values and errors are delivered on the **main
-    /// run loop**. The unstructured `Task { … }` below does *not* preserve
-    /// caller actor isolation (it inherits a nonisolated context), so the
-    /// `promise(.success/.failure)` call resumes on the cooperative thread
-    /// pool. Without an explicit hop, every UI consumer downstream would have
-    /// to add `.receive(on: DispatchQueue.main)` themselves *and* remember
-    /// that any `@MainActor`-isolated symbol they touch (e.g., a SwiftUI
-    /// state mutation, a UIKit binding, a `@MainActor` view-model method)
-    /// would trap on Swift 6's runtime isolation check (`_swift_task_check`-
+    /// dispatch queue** (that is, on the **main thread**). The unstructured
+    /// `Task { … }` below does *not* preserve caller actor isolation (it
+    /// inherits a nonisolated context), so the `promise(.success/.failure)`
+    /// call resumes on the cooperative thread pool. Without an explicit hop,
+    /// every UI consumer downstream would have to add
+    /// `.receive(on: DispatchQueue.main)` themselves *and* remember that any
+    /// `@MainActor`-isolated symbol they touch (e.g., a SwiftUI state
+    /// mutation, a UIKit binding, a `@MainActor` view-model method) would
+    /// trap on Swift 6's runtime isolation check (`_swift_task_check`-
     /// `IsolatedSwift`) under iOS 26 / Swift 6.2. Hopping back to the main
-    /// run loop here makes the wrapper safe-by-default for the overwhelming
-    /// majority of consumers (UI apps); non-UI consumers pay one extra
-    /// scheduler hop, which is negligible compared to the network round-trip
-    /// the publisher's about to surface.
+    /// dispatch queue here makes the wrapper safe-by-default for the
+    /// overwhelming majority of consumers (UI apps); non-UI consumers pay
+    /// one extra scheduler hop, which is negligible compared to the network
+    /// round-trip the publisher's about to surface.
     ///
     /// Subscriber cancellation propagates to the underlying `Task`, so subscribers tearing down a
     /// pipeline mid-flight don't leak the in-flight network call.


### PR DESCRIPTION
Architecturally, `Future + Task { … promise(.success(try await …)) }`
does not preserve caller actor isolation — the unstructured Task inherits
a nonisolated context, so the promise resolves on the cooperative thread
pool. This was always semantically fine under Swift 5, but lands as an
EXC_BREAKPOINT on Swift 6.2 / iOS 26 the moment any subscriber's
downstream pipeline touches a `@MainActor`-isolated symbol — the runtime
isolation check (`_swift_task_checkIsolatedSwift`) traps before the
subscriber's `.sink` even runs.

The overwhelming majority of consumers are UI apps that need values on
the main thread anyway. Append `.receive(on: DispatchQueue.main)` inside
`callAsync` so the wrapper is safe-by-default — every `*Reactive` method
now delivers on the main run loop, with no opaque trap if the consumer
forgets to hop. Non-UI consumers pay one extra scheduler hop, which is
negligible compared to the network round-trip the publisher's about to
surface.

Cancellation behaviour is unchanged — the `handleEvents(receiveCancel:)`
chain still fires the underlying `Task.cancel()` immediately when the
subscriber tears down, regardless of which scheduler the cancellation
arrives on.

413 tests pass; pipeline observable in the consumer (Zhip) where the
previous EXC_BREAKPOINT on "Create wallet" is gone.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
